### PR TITLE
feat: configure the keymap in debugger mode.

### DIFF
--- a/homefiles/.config/nvim/init.lua
+++ b/homefiles/.config/nvim/init.lua
@@ -271,12 +271,13 @@ map { "n", "<leader>np", function ()
     }
 -- debugger actions.
 -- normal actions
-map { "n", "<F5>", function () require "dap".continue() end }
-map { "n", "<F10>", function () require "dap".step_over() end }
-map { "n", "<F11>", function () require "dap".step_into() end }
-map { "n", "<F12>", function () require "dap".step_out() end }
-map { "n", "<F17>", function () require "dap".terminate() end } -- F17 is shift-F5
+map { "n", "<leader>dd", function ()
+        local dap = require "dap"
+        dap.set_breakpoint()
+        dap.continue()
+      end
+    }
 -- inspections.
-map { "n", "<leader>b", function () require "dap".toggle_breakpoint() end }
+map { "n", "<leader>db", function () require "dap".toggle_breakpoint() end }
 
 -- # COMMANDS ##################################################################

--- a/homefiles/.config/nvim/lua/dapmap.lua
+++ b/homefiles/.config/nvim/lua/dapmap.lua
@@ -1,22 +1,23 @@
 local M = {}
 
-local origin_nmaps = {}
+local winid = nil
+local original_nmaps = {}
 local function nmap(lhs, rhs, desc)
-  origin_nmaps[lhs] = vim.fn.maparg(lhs, "n", false, true)
+  original_nmaps[lhs] = vim.fn.maparg(lhs, "n", false, true)
   vim.keymap.set("n", lhs, rhs, { desc = desc })
 end
 local function resetnmap()
-  for key, value in pairs(origin_nmaps) do
+  for key, value in pairs(original_nmaps) do
     if value and not vim.tbl_isempty(value) then
       vim.keymap.set("n", key, value.rhs, value.opt)
     else
       vim.keymap.del("n", key)
     end
   end
-  origin_nmaps = {}
+  original_nmaps = {}
 end
 
-local function active()
+local function enable()
   vim.bo.modifiable = false
   local dap = require "dap"
   for name, maps in pairs(M.keymap) do
@@ -26,24 +27,24 @@ local function active()
   end
 end
 
-local function inactive()
+local function disable()
   vim.bo.modifiable = true
   resetnmap()
 end
 
 function M.setup(keymap)
-  if M.winid then
+  if winid then
     return
   end
 
   M.keymap = keymap
-  M.winid = vim.api.nvim_get_current_win()
+  winid = vim.api.nvim_get_current_win()
   M.autocmds =
   { vim.api.nvim_create_autocmd(
       "WinEnter"
       , { callback = function ()
-            if M.winid and M.winid == vim.api.nvim_get_current_win() then
-              active()
+            if winid and winid == vim.api.nvim_get_current_win() then
+              enable()
             end
           end
         }
@@ -51,26 +52,27 @@ function M.setup(keymap)
   , vim.api.nvim_create_autocmd(
       "WinLeave"
       , { callback = function ()
-            if M.winid and M.winid == vim.api.nvim_get_current_win() then
-              inactive()
+            if winid and winid == vim.api.nvim_get_current_win() then
+              disable()
             end
           end
         }
     )
   }
-  active()
+  enable()
 end
 
 function M.close()
-  if M.winid == nil then
+  if winid == nil then
     return
   end
 
-  M.winid = nil
+  winid = nil
   for _, id in ipairs(M.autocmds) do
     vim.api.nvim_del_autocmd(id)
   end
-  inactive()
+  M.autocmds = nil
+  disable()
 end
 
 return M

--- a/homefiles/.config/nvim/lua/dapmap.lua
+++ b/homefiles/.config/nvim/lua/dapmap.lua
@@ -1,41 +1,50 @@
 local dapmap = {}
 local nmaps = {}
-local mapopt = {}
 
-local function nmap(lhs, rhs)
+local function nmap(lhs, rhs, desc)
   nmaps[lhs] = vim.fn.maparg(lhs, "n", false, true)
-  vim.keymap.set("n", lhs, rhs, mapopt)
+  vim.keymap.set("n", lhs, rhs, { desc = desc })
 end
 local function resmap()
   for key, value in pairs(nmaps) do
     if value and not vim.tbl_isempty(value) then
-      vim.keymap.set("n", key, value.rhs, mapopt)
+      vim.keymap.set("n", key, value.rhs, value.opt)
     else
-      vim.keymap.del("n", key, mapopt)
+      vim.keymap.del("n", key)
     end
   end
   nmaps = {}
 end
 
-local map =
-{ continue   = { key = "<leader>dc", func = function () require "dap".continue() end}
-, pause      = { key = "<leader>dp", func = function () require "dap".pause() end}
-, run_last   = { key = nil, func = function () require "dap".run_last() end}
-, step_back  = { key = "<Up>", func = function () require "dap".step_back() end}
-, step_into  = { key = "<Right>", func = function () require "dap".step_into() end}
-, step_out   = { key = "<Left>", func = function () require "dap".step_out() end}
-, step_over  = { key = "<Down>", func = function () require "dap".step_over() end}
-, terminate  = { key = "<leader>dx", func = function () require "dap".terminate() end}
+local nkeymap =
+{ continue          = { "dd", "c"}
+, pause             = "p"
+, toggle_breakpoint = { "db", "a" }
+, clear_breakpoints = "cb"
+, step_back         = "u"
+, step_into         = "i"
+, step_out          = "o"
+, step_over         = "s"
+, terminate         = "x"
 }
 function dapmap.setup()
-  for _, value in pairs(map) do
-    if value and not vim.tbl_isempty(value) then
-      if value.key then
-        nmap(value.key, value.func)
+  local dap = require "dap"
+  vim.bo.modifiable = false
+
+  for key, value in pairs(nkeymap) do
+    if value then
+      local smap = function (lhs) nmap(lhs, function () dap[key]() end, key) end
+      if type(value) == "table" then
+        for _, i in ipairs(value) do
+          smap(i)
+        end
+      else
+        smap(value)
       end
     end
   end
   return function ()
+    vim.bo.modifiable = true
     resmap()
   end
 end

--- a/homefiles/.config/nvim/lua/dapmap.lua
+++ b/homefiles/.config/nvim/lua/dapmap.lua
@@ -1,15 +1,5 @@
 local M = {}
 
-local function resetnmap(original_nmaps)
-  for key, value in pairs(original_nmaps) do
-    if value and not vim.tbl_isempty(value) then
-      vim.keymap.set("n", key, value.rhs, value.opt)
-    else
-      vim.keymap.del("n", key)
-    end
-  end
-end
-
 local function enable(keymap)
   vim.bo.modifiable = false
   local dap = require "dap"
@@ -26,7 +16,13 @@ end
 
 local function disable(original_nmaps)
   vim.bo.modifiable = true
-  resetnmap(original_nmaps)
+  for key, value in pairs(original_nmaps) do
+    if value and not vim.tbl_isempty(value) then
+      vim.keymap.set("n", key, value.rhs, value.opt)
+    else
+      vim.keymap.del("n", key)
+    end
+  end
 end
 
 function M.setup(keymap)

--- a/homefiles/.config/nvim/lua/dapmap.lua
+++ b/homefiles/.config/nvim/lua/dapmap.lua
@@ -1,0 +1,43 @@
+local dapmap = {}
+local nmaps = {}
+local mapopt = {}
+
+local function nmap(lhs, rhs)
+  nmaps[lhs] = vim.fn.maparg(lhs, "n", false, true)
+  vim.keymap.set("n", lhs, rhs, mapopt)
+end
+local function resmap()
+  for key, value in pairs(nmaps) do
+    if value and not vim.tbl_isempty(value) then
+      vim.keymap.set("n", key, value.rhs, mapopt)
+    else
+      vim.keymap.del("n", key, mapopt)
+    end
+  end
+  nmaps = {}
+end
+
+local map =
+{ continue   = { key = "<leader>dc", func = function () require "dap".continue() end}
+, pause      = { key = "<leader>dp", func = function () require "dap".pause() end}
+, run_last   = { key = nil, func = function () require "dap".run_last() end}
+, step_back  = { key = "<Up>", func = function () require "dap".step_back() end}
+, step_into  = { key = "<Right>", func = function () require "dap".step_into() end}
+, step_out   = { key = "<Left>", func = function () require "dap".step_out() end}
+, step_over  = { key = "<Down>", func = function () require "dap".step_over() end}
+, terminate  = { key = "<leader>dx", func = function () require "dap".terminate() end}
+}
+function dapmap.setup()
+  for _, value in pairs(map) do
+    if value and not vim.tbl_isempty(value) then
+      if value.key then
+        nmap(value.key, value.func)
+      end
+    end
+  end
+  return function ()
+    resmap()
+  end
+end
+
+return dapmap

--- a/homefiles/.config/nvim/lua/dapmap.lua
+++ b/homefiles/.config/nvim/lua/dapmap.lua
@@ -1,52 +1,76 @@
-local dapmap = {}
-local nmaps = {}
+local M = {}
 
+local origin_nmaps = {}
 local function nmap(lhs, rhs, desc)
-  nmaps[lhs] = vim.fn.maparg(lhs, "n", false, true)
+  origin_nmaps[lhs] = vim.fn.maparg(lhs, "n", false, true)
   vim.keymap.set("n", lhs, rhs, { desc = desc })
 end
-local function resmap()
-  for key, value in pairs(nmaps) do
+local function resetnmap()
+  for key, value in pairs(origin_nmaps) do
     if value and not vim.tbl_isempty(value) then
       vim.keymap.set("n", key, value.rhs, value.opt)
     else
       vim.keymap.del("n", key)
     end
   end
-  nmaps = {}
+  origin_nmaps = {}
 end
 
-local nkeymap =
-{ continue          = { "dd", "c"}
-, pause             = "p"
-, toggle_breakpoint = { "db", "a" }
-, clear_breakpoints = "cb"
-, step_back         = "u"
-, step_into         = "i"
-, step_out          = "o"
-, step_over         = "s"
-, terminate         = "x"
-}
-function dapmap.setup()
-  local dap = require "dap"
+local function active()
   vim.bo.modifiable = false
-
-  for key, value in pairs(nkeymap) do
-    if value then
-      local smap = function (lhs) nmap(lhs, function () dap[key]() end, key) end
-      if type(value) == "table" then
-        for _, i in ipairs(value) do
-          smap(i)
-        end
-      else
-        smap(value)
-      end
+  local dap = require "dap"
+  for name, maps in pairs(M.keymap) do
+    for _, lhs in ipairs( type(maps) == "table" and maps or { maps } ) do
+      nmap(lhs, function () dap[name]() end, name)
     end
   end
-  return function ()
-    vim.bo.modifiable = true
-    resmap()
-  end
 end
 
-return dapmap
+local function inactive()
+  vim.bo.modifiable = true
+  resetnmap()
+end
+
+function M.setup(keymap)
+  if M.winid then
+    return
+  end
+
+  M.keymap = keymap
+  M.winid = vim.api.nvim_get_current_win()
+  M.autocmds =
+  { vim.api.nvim_create_autocmd(
+      "WinEnter"
+      , { callback = function ()
+            if M.winid and M.winid == vim.api.nvim_get_current_win() then
+              active()
+            end
+          end
+        }
+    )
+  , vim.api.nvim_create_autocmd(
+      "WinLeave"
+      , { callback = function ()
+            if M.winid and M.winid == vim.api.nvim_get_current_win() then
+              inactive()
+            end
+          end
+        }
+    )
+  }
+  active()
+end
+
+function M.close()
+  if M.winid == nil then
+    return
+  end
+
+  M.winid = nil
+  for _, id in ipairs(M.autocmds) do
+    vim.api.nvim_del_autocmd(id)
+  end
+  inactive()
+end
+
+return M

--- a/homefiles/.config/nvim/lua/plugins.lua
+++ b/homefiles/.config/nvim/lua/plugins.lua
@@ -442,21 +442,27 @@ return
     , "nvim-neotest/nvim-nio"
     }
   , config = function ()
-      local dap   = require "dap"
-      local dapui = require "dapui"
+      local dap    = require "dap"
+      local dapui  = require "dapui"
+      local dapmap = require "dapmap"
 
       dapui.setup()
+      local dapmap_close = function () end
 
       dap.listeners.before.attach.dapui_config = function ()
+        dapmap_close = dapmap.setup()
         dapui.open()
       end
       dap.listeners.before.launch.dapui_config = function ()
+        dapmap_close = dapmap.setup()
         dapui.open()
       end
       dap.listeners.before.event_terminated.dapui_config = function ()
+        dapmap_close()
         dapui.close()
       end
       dap.listeners.before.event_exited.dapui_config = function ()
+        dapmap_close()
         dapui.close()
       end
     end

--- a/homefiles/.config/nvim/lua/plugins.lua
+++ b/homefiles/.config/nvim/lua/plugins.lua
@@ -445,24 +445,34 @@ return
       local dap    = require "dap"
       local dapui  = require "dapui"
       local dapmap = require "dapmap"
+      local keymap =
+      { continue          = { "dd", "c" }
+      , pause             = "p"
+      , toggle_breakpoint = { "db", "a" }
+      , clear_breakpoints = "cb"
+      , step_back         = "u"
+      , step_into         = "i"
+      , step_out          = "o"
+      , step_over         = "s"
+      , terminate         = "x"
+      }
 
       dapui.setup()
-      local dapmap_close = function () end
 
       dap.listeners.before.attach.dapui_config = function ()
-        dapmap_close = dapmap.setup()
+        dapmap.setup(keymap)
         dapui.open()
       end
       dap.listeners.before.launch.dapui_config = function ()
-        dapmap_close = dapmap.setup()
+        dapmap.setup(keymap)
         dapui.open()
       end
       dap.listeners.before.event_terminated.dapui_config = function ()
-        dapmap_close()
+        dapmap.close()
         dapui.close()
       end
       dap.listeners.before.event_exited.dapui_config = function ()
-        dapmap_close()
+        dapmap.close()
         dapui.close()
       end
     end

--- a/homefiles/.config/nvim/lua/plugins.lua
+++ b/homefiles/.config/nvim/lua/plugins.lua
@@ -457,22 +457,20 @@ return
       , terminate         = "x"
       }
 
+      local dapmapclose
       dapui.setup()
 
       dap.listeners.before.attach.dapui_config = function ()
-        dapmap.setup(keymap)
+        dapmapclose = dapmap.setup(keymap)
         dapui.open()
       end
       dap.listeners.before.launch.dapui_config = function ()
-        dapmap.setup(keymap)
+        dapmapclose = dapmap.setup(keymap)
         dapui.open()
       end
-      dap.listeners.before.event_terminated.dapui_config = function ()
-        dapmap.close()
-        dapui.close()
-      end
       dap.listeners.before.event_exited.dapui_config = function ()
-        dapmap.close()
+        ---@diagnostic disable-next-line: need-check-nil
+        dapmapclose()
         dapui.close()
       end
     end


### PR DESCRIPTION
When dapui is up, users can use simpler shortcuts to execute debug commands instead of using shortcuts like F10/F11.