### PR TITLE
feat: fix nvim-dap buffer readonly state management with filetype fil…

### DIFF
--- a/homefiles/.config/nvim/lua/dapmap.lua
+++ b/homefiles/.config/nvim/lua/dapmap.lua
@@ -1,8 +1,6 @@
 local M = {}
 
 local function enable(keymap)
-  vim.bo.modifiable = false
-
   local dap = require "dap"
   local original_nmaps = {}
   for name, maps in pairs(keymap) do
@@ -16,8 +14,6 @@ local function enable(keymap)
 end
 
 local function disable(original_nmaps)
-  vim.bo.modifiable = true
-
   for key, value in pairs(original_nmaps) do
     if value and not vim.tbl_isempty(value) then
       vim.keymap.set("n", key, value.rhs, value.opt)
@@ -27,25 +23,28 @@ local function disable(original_nmaps)
   end
 end
 
-function M.setup(keymap)
-  local winid          = vim.api.nvim_get_current_win()
+function M.setup(keymap, filetype)
+  local tracked_bufs = {}
+
+  local function set_readonly(bufnr)
+    if filetype and vim.bo[bufnr].filetype ~= filetype then
+      return
+    end
+
+    if not tracked_bufs[bufnr] then
+      tracked_bufs[bufnr] = vim.bo[bufnr].modifiable
+    end
+    vim.bo[bufnr].modifiable = false
+  end
+
+  set_readonly(vim.api.nvim_get_current_buf())
   local original_nmaps = enable(keymap)
+
   local autocmds       =
   { vim.api.nvim_create_autocmd(
-      "WinEnter"
+      "BufEnter"
     , { callback = function ()
-          if winid == vim.api.nvim_get_current_win() then
-            original_nmaps = enable(keymap)
-          end
-        end
-      }
-    )
-  , vim.api.nvim_create_autocmd(
-      "WinLeave"
-    , { callback = function ()
-          if winid == vim.api.nvim_get_current_win() then
-            disable(original_nmaps)
-          end
+          set_readonly(vim.api.nvim_get_current_buf())
         end
       }
     )
@@ -54,6 +53,11 @@ function M.setup(keymap)
   return function ()
     for _, id in ipairs(autocmds) do
       vim.api.nvim_del_autocmd(id)
+    end
+    for bufnr, original_modifiable in pairs(tracked_bufs) do
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        vim.bo[bufnr].modifiable = original_modifiable
+      end
     end
     disable(original_nmaps)
   end

--- a/homefiles/.config/nvim/lua/dapmap.lua
+++ b/homefiles/.config/nvim/lua/dapmap.lua
@@ -60,6 +60,8 @@ function M.setup(keymap, filetype)
       end
     end
     disable(original_nmaps)
+    original_nmaps = {}
+    tracked_bufs   = {}
   end
 end
 

--- a/homefiles/.config/nvim/lua/plugins.lua
+++ b/homefiles/.config/nvim/lua/plugins.lua
@@ -449,8 +449,8 @@ return
       , terminate         = "x"
       }
 
-      local function uiconfig()
-        local cleanup = dapmap.setup(keymap)
+      local function uiconfig(session)
+        local cleanup = dapmap.setup(keymap, session.filetype)
 
         dap.listeners.before.event_exited.uiconfig = function ()
           cleanup()


### PR DESCRIPTION
Fix nvim-dap readonly buffer state leak

**Problem**
When debugging with nvim-dap, if the debugger crashes or exits abnormally after stepping into other files, those buffers remain readonly and cannot be edited.